### PR TITLE
fix: 🐛 add to cart button was not showing if astra or other builder is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ bash clean.sh
 
 ## changelog
 
+### v1.3.1
+
+- **Fix**: Add to card button in product page was not showing certain themes are is used.
+
 ### v1.3
 
 - **New**: Stripe renewal added.

--- a/includes/Frontend/Product.php
+++ b/includes/Frontend/Product.php
@@ -93,13 +93,13 @@ class Product {
 	 */
 	public function text_if_active() {
 		global $product;
-		$product = sdevs_get_subscription_product( $product );
-		if ( ! $product->is_type( 'simple' ) ) {
+		$sdevs_product = sdevs_get_subscription_product( $product );
+		if ( ! $sdevs_product->is_type( 'simple' ) ) {
 			return;
 		}
 
-		if ( $product->is_enabled() ) {
-			$limit = $product->get_limit();
+		if ( $sdevs_product->is_enabled() ) {
+			$limit = $sdevs_product->get_limit();
 			if ( 'unlimited' === $limit ) {
 				return;
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,9 @@ Customer can set status to **Pending cancellation**, which subscription will be 
 
 == Changelog ==
 
+= 1.3.1 =
+- **Fix**: Add to card button in product page was not showing certain themes are is used.
+
 = 1.3 =
 - **New**: Stripe renewal added.
 - **New**: Trial feature added.

--- a/subscription.php
+++ b/subscription.php
@@ -3,7 +3,7 @@
 Plugin Name: Subscription for WooCommerce
 Plugin URI: https://wordpress.org/plugins/subscription
 Description: Allow your customers to order once and get their products and services every month/week.
-Version: 1.3
+Version: 1.3.1
 Author: SpringDevs
 Author URI: https://springdevs.com/
 Requires Plugins: woocommerce
@@ -59,7 +59,7 @@ final class Sdevs_Subscription {
 	 *
 	 * @var string
 	 */
-	const version = '1.3.0';
+	const version = '1.3.1';
 
 	/**
 	 * Holds various class instances


### PR DESCRIPTION
This pull request includes a small but important change to the `text_if_active` method in `includes/Frontend/Product.php`. 

The change includes separating the new `$product` with the sdevs subscription utility functions so that it does not overwrite the global variable.